### PR TITLE
Allow case sensitive keys for iOS

### DIFF
--- a/internal/translations/language_file.ios.go
+++ b/internal/translations/language_file.ios.go
@@ -19,9 +19,8 @@ func (f *iosLanguageFile) write(translation *translation, io io.Writer) error {
 		"\"", "\\\"",
 		"\n", "\\n")
 
-	for _, k := range translation.keys {
-		key := strings.ToUpper(k)
-		value := translation.get(k)
+	for _, key := range translation.keys {
+		value := translation.get(key)
 		_, err := io.Write([]byte(fmt.Sprintf("\"%s\" = \"%s\";\n", key, escape.Replace(value))))
 		if err != nil {
 			return err

--- a/internal/translations/language_file.ios.support.go
+++ b/internal/translations/language_file.ios.support.go
@@ -50,9 +50,8 @@ func (f *iosSupportLanguageFile) write(translation *translation, io io.Writer) e
 	}
 
 	list := make([]*line, 0)
-	for _, k := range translation.keys {
-		key := strings.ToUpper(k)
-		value := translation.get(k)
+	for _, key := range translation.keys {
+		value := translation.get(key)
 		var item *line
 
 		matches := regex.FindAllStringSubmatch(value, -1)

--- a/internal/translations/testdata/android-da.expected
+++ b/internal/translations/testdata/android-da.expected
@@ -4,4 +4,5 @@
 	<string name="something_for_xml">Det er som &amp; og &lt;b&gt;fremhævet&lt;/b&gt; \"tekst\" eller 官话</string>
 	<string name="something_with_arguments">Noget med %1$s og %2$s</string>
 	<string name="watch_out_for_new_lines">Tekst\nmed\nline\nskift</string>
+	<string name="ioscasesensitivekey">Noget</string>
 </resources>

--- a/internal/translations/testdata/android-en.expected
+++ b/internal/translations/testdata/android-en.expected
@@ -4,4 +4,5 @@
 	<string name="something_for_xml">It\'s like &amp; and &lt;b&gt;bold&lt;/b&gt; \"text\" or 官话</string>
 	<string name="something_with_arguments">Something with %1$s and %2$s</string>
 	<string name="watch_out_for_new_lines">Text\nwith\nnew\nlines</string>
+	<string name="ioscasesensitivekey">Something</string>
 </resources>

--- a/internal/translations/testdata/input.csv
+++ b/internal/translations/testdata/input.csv
@@ -10,5 +10,6 @@ lines","Tekst
 med
 line
 skift",
+iOSCaseSensitiveKey,,Something,Noget,
 ,,Title,,
 ,,,,

--- a/internal/translations/testdata/ios-da.expected
+++ b/internal/translations/testdata/ios-da.expected
@@ -3,3 +3,4 @@
 "SOMETHING_FOR_XML" = "Det er som & og <b>fremhævet</b> \"tekst\" eller 官话";
 "SOMETHING_WITH_ARGUMENTS" = "Noget med %1 og %2";
 "WATCH_OUT_FOR_NEW_LINES" = "Tekst\nmed\nline\nskift";
+"iOSCaseSensitiveKey" = "Noget";

--- a/internal/translations/testdata/ios-en.expected
+++ b/internal/translations/testdata/ios-en.expected
@@ -3,3 +3,4 @@
 "SOMETHING_FOR_XML" = "It's like & and <b>bold</b> \"text\" or 官话";
 "SOMETHING_WITH_ARGUMENTS" = "Something with %1 and %2";
 "WATCH_OUT_FOR_NEW_LINES" = "Text\nwith\nnew\nlines";
+"iOSCaseSensitiveKey" = "Something";

--- a/internal/translations/testdata/ios-swift.expected
+++ b/internal/translations/testdata/ios-swift.expected
@@ -6,4 +6,5 @@ public struct Translations {
 	static let SOMETHING_FOR_XML = NSLocalizedString("SOMETHING_FOR_XML", comment: "")
 	static func SOMETHING_WITH_ARGUMENTS(_ p1: String, _ p2: String) -> String { return NSLocalizedString("SOMETHING_WITH_ARGUMENTS", comment: "").replacingOccurrences(of: "%1", with: p1).replacingOccurrences(of: "%2", with: p2) }
 	static let WATCH_OUT_FOR_NEW_LINES = NSLocalizedString("WATCH_OUT_FOR_NEW_LINES", comment: "")
+	static let iOSCaseSensitiveKey = NSLocalizedString("iOSCaseSensitiveKey", comment: "")
 }

--- a/internal/translations/testdata/json-en.expected
+++ b/internal/translations/testdata/json-en.expected
@@ -1,4 +1,5 @@
 {
+  "ioscasesensitivekey": "Something",
   "something": "Something",
   "something_escaped": "Something with ,",
   "something_for_xml": "It's like \u0026 and \u003cb\u003ebold\u003c/b\u003e \"text\" or 官话",

--- a/internal/translations/translations.go
+++ b/internal/translations/translations.go
@@ -3,7 +3,6 @@ package translations
 import (
 	"encoding/csv"
 	"os"
-	"strings"
 )
 
 type translationData struct {
@@ -41,8 +40,7 @@ func (t *translationData) translation(keyIndex int, valueIndex int, useFallback 
 		if useFallback && s == "" {
 			s = r[fallbackIndex-1]
 		}
-
-		items[strings.ToLower(k)] = s
+		items[k] = s
 	}
 	return newTranslation(items)
 }


### PR DESCRIPTION
This is required for `InfoPlist.strings` to work properly.